### PR TITLE
SDI12 not working when other Serial used than Serial3

### DIFF
--- a/SDI12.h
+++ b/SDI12.h
@@ -46,6 +46,7 @@ public:
         RX_PIN( nullptr ),
         SET( nullptr ),
         CLEAR( nullptr ),
+        STATUS_REG( nullptr ),
         PIN_NUM_RX( 0 ),
         PIN_NUM_TX( 0 )
     {
@@ -66,6 +67,7 @@ private:
     volatile uint8_t  SCGC4;
     volatile uint32_t *SET;
     volatile uint32_t *CLEAR;
+    volatile uint8_t  *STATUS_REG;
     volatile uint32_t BITMASK;
     uint8_t           PIN_NUM_RX;
     uint8_t           PIN_NUM_TX;


### PR DESCRIPTION
Hi Duff2013,

first of all, thank you for that great SDI12-Teensy library!

I started using your SDI12-library for a project with the Teensy 3.5 and found an issue with other Serials than Serial3.

***Issue***
When using another Serial than Serial3 my program does not respond any more, at all.

***Problem***
When testing bits in the status register, for example in the following case
```c
int SDI12::send_command( const void *cmd, uint8_t count, uint8_t type ) {
...
    do { yield( ); } while ( !( UART2_S1 & UART_S1_IDLE ) );            // wait for i/o to become idle
...
}
```
Serial3 (register UART2_S1) was hard coded into the function. Even when initialising an SDI12-object with Serial1 the functions were testing bits in the status register of Serial3 and the while-condition accidentally created an infinty-loop.

***Solution***
I added a pointer to the status register of the particular Serial used when the SDI12-object was initialised. With that change in code I can communicate with my SDI12-sensors on Serial1 - 3.

Cheers
Daniel