### PR TITLE
Fix change address

### DIFF
--- a/SDI12.cpp
+++ b/SDI12.cpp
@@ -325,13 +325,6 @@ int SDI12::changeAddress( const uint8_t new_address ) {
         ioActive = false;
         return -3;
     }
-
-    error = isActive( );
-
-    if ( error ) {
-        ioActive = false;
-        return -4;
-    }
     
     uint8_t command[4];
     command[0] = sensor.address;

--- a/SDI12.h
+++ b/SDI12.h
@@ -46,6 +46,7 @@ public:
         RX_PIN( nullptr ),
         SET( nullptr ),
         CLEAR( nullptr ),
+        STATUS_REG( nullptr ),
         PIN_NUM_RX( 0 ),
         PIN_NUM_TX( 0 )
     {
@@ -66,6 +67,7 @@ private:
     volatile uint8_t  SCGC4;
     volatile uint32_t *SET;
     volatile uint32_t *CLEAR;
+    volatile uint8_t  *STATUS_REG;
     volatile uint32_t BITMASK;
     uint8_t           PIN_NUM_RX;
     uint8_t           PIN_NUM_TX;


### PR DESCRIPTION
Hi again,

this pull request includes the other fix with the Serial. So I think you could either merge the other one first and than this one, or only this one and close the other one. Only if you are satisfied with the result of course.

***Issue***
Function changeAddress() always returns -4 and never sends anyting via the data line.

***Problem***
ioActive() is tested and set in the very beginning of the function. A subsequent call of isActive() does the very same thing and since ioActive has been set already, isActive() will here always return -4 as error.
```c++
int SDI12::changeAddress( const uint8_t new_address ) {
    if ( ioActive ) return -5;
    else ioActive = true;

    ...

    error = isActive( );

    if ( error ) {
        ioActive = false;
        return -4;
    }
}
```

***Solution***
Since changeAddress() is the only function calling isActive() the easiest solution would be to delete the call of isActive() entirely.